### PR TITLE
Replace keypress event listener with keydown

### DIFF
--- a/src/hooks/useActiveHook.js
+++ b/src/hooks/useActiveHook.js
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef } from "react";
 export function useActive(time) {
   const [active, setActive] = useState(false);
   const timer = useRef();
-  const events = ["keypress", "mousemove", "touchmove", "click", "scroll"];
+  const events = ["keydown", "mousemove", "touchmove", "click", "scroll"];
 
   useEffect(() => {
     const handleEvent = () => {


### PR DESCRIPTION
According to u/wy35 and confirmed with MDN docs: “The keydown event is fired when a key is pressed. Unlike the keypress event, the keydown event is fired for all keys, regardless of whether they produce a character value. “